### PR TITLE
fix: deploy script not working on Windows

### DIFF
--- a/projects/basic/package.json
+++ b/projects/basic/package.json
@@ -5,7 +5,7 @@
     "dev": "vite",
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev ./dist",
-    "deploy": "$npm_execpath run build && wrangler pages deploy ./dist"
+    "deploy": "npm run build && wrangler pages deploy ./dist"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
`$npm_execpath` is not available on Windows environments, see [this explanation](https://gist.github.com/coryhouse/b26f49bead69066844d9?permalink_comment_id=4223563#gistcomment-4223563). 

To improve the initial user experience and adoption, I recommend we stick with `npm run` and let the user manually change to their preferred package manager once they start editing the `package.json` themselves.